### PR TITLE
Added new dontShowLogDialog method to the ChangeLog class.

### DIFF
--- a/library/src/de/cketti/library/changelog/ChangeLog.java
+++ b/library/src/de/cketti/library/changelog/ChangeLog.java
@@ -241,6 +241,14 @@ public class ChangeLog {
     }
 
     /**
+     * Call if you don't want to show the change log for this app version. Future calls to {@link ChangeLog#isFirstRun()} and {@link ChangeLog#isFirstRunEver()} will return {@code false} for the
+     * current app version.
+     */
+    public void dontShowLogDialog() {
+        updateVersionInPreferences();
+    }
+
+    /**
      * Get the "What's New" dialog.
      *
      * @return An AlertDialog displaying the changes since the previous installed version of your


### PR DESCRIPTION
This feature is useful when you want to not show a change log dialog for the current app version.
A good reason to do this is if you are showing a new user experience on initial install of the app
and do not want to show the change log except for on subsequent app updates.
