### PR TITLE
Remove white spaces and line breaks from changes text.

### DIFF
--- a/ckChangeLog-core/src/main/java/de/cketti/library/changelog/ChangeLog.java
+++ b/ckChangeLog-core/src/main/java/de/cketti/library/changelog/ChangeLog.java
@@ -284,8 +284,10 @@ public final class ChangeLog {
         while (eventType != XmlPullParser.END_TAG || xml.getName().equals(ChangeTag.NAME)) {
             if (eventType == XmlPullParser.START_TAG && xml.getName().equals(ChangeTag.NAME)) {
                 eventType = xml.next();
-
-                changes.add(xml.getText());
+                String text = xml.getText();
+                text = text.trim();
+                text = text.replaceAll("\\s+", " ");
+                changes.add(text);
             }
             eventType = xml.next();
         }


### PR DESCRIPTION
I noticed that `\n` from multi-line text and multiple spaces are kept when the changes text is read from XML.

---

Feel free to rebase the branch onto HEAD before merging it.